### PR TITLE
WP-17820 set query timeout for MsSql to avoid long hanging

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-mssql"
-version = "1.0.8"
+version = "1.0.9"
 description = "Singer.io tap for extracting data from SQL Server - PipelineWise compatible"
 authors = ["Stitch"]
 repository = "https://github.com/wintersrd/pipelinewise-tap-mssql"

--- a/tap_mssql/connection.py
+++ b/tap_mssql/connection.py
@@ -42,6 +42,7 @@ class MSSQLConnection(pymssql.Connection):
         }
         try:
             conn = pymssql._mssql.connect(**args)
+            conn.query_timeout = 60
         except pymssql._mssql.MSSQLDatabaseException as e:
             message = str(e)
             # pymssql throws same error for both wrong credentials and wrong database

--- a/tap_mssql/connection.py
+++ b/tap_mssql/connection.py
@@ -42,7 +42,10 @@ class MSSQLConnection(pymssql.Connection):
         }
         try:
             conn = pymssql._mssql.connect(**args)
-            conn.query_timeout = 60
+            # default query timeout is set to 0, which means to wait indefinitely for results.
+            # two cases for query timing out, the query execution is taking longer time than the query_timeout or the connection is lost.
+            # for now, set the query_timeout for 1 hour
+            conn.query_timeout = 3600
         except pymssql._mssql.MSSQLDatabaseException as e:
             message = str(e)
             # pymssql throws same error for both wrong credentials and wrong database

--- a/tap_mssql/sync_strategies/common.py
+++ b/tap_mssql/sync_strategies/common.py
@@ -10,6 +10,7 @@ import uuid
 import singer.metrics as metrics
 from singer import metadata
 from singer import utils
+from datetime import datetime
 
 LOGGER = singer.get_logger()
 
@@ -144,9 +145,19 @@ def sync_query(cursor, catalog_entry, state, select_sql, columns, stream_version
     # query_string = cursor.mogrify(select_sql, params)
 
     time_extracted = utils.now()
+    print("---------here goes the start time---------")
+    print(datetime.now())
     cursor.execute(select_sql, params)
+    
+    print("---------here goes the end time---------")
+    print(datetime.now())
 
+    print("-----------------fetch the first one-----------------")
     row = cursor.fetchone()
+    print(row)
+    print("-----------------done-----------------")
+    print(datetime.now())
+    raise Exception("stop here")
     rows_saved = 0
 
     database_name = get_database_name(catalog_entry)


### PR DESCRIPTION
JIRA: https://varicent.atlassian.net/browse/WP-17820

For _msSql module, the `query_timeout` is default to 0 which means waiting indefinitely until the server responses or query finishes. This could result in the long wait for Goodlife Sql Server import lasting for 6 hours which suppose to finish in around 30 minutes.

Here, set the query_timeout to one hour. Based on the testing result, the query for a large dataset of 4.5 GB (8 million rows, 50 cols) finished in around one second to finish.
The `query_timeout` wouldn't apply to the fetching data process.
